### PR TITLE
Add new flag GIT_HTTP_MOCK_SERVER_PERSIST_CHANGES

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Same thing for SSH:
 - `GIT_SSH_MOCK_SERVER_ROOT` default is `process.cwd()`
 - `GIT_SSH_MOCK_SERVER_PASSWORD` activate Password Authentication and use this password (leave blank to allow anonymous SSH access.)
 - `GIT_SSH_MOCK_SERVER_PUBKEY` activate PubKey Authentication using the self-generated keypair (leave blank to allow anonymous SSH access.)
+- `GIT_HTTP_MOCK_SERVER_PERSIST_CHANGES` set to 'yes' to disable copy-on-write and write changes to the filesystem
 
 ### .htpasswd support (http-only)
 

--- a/http-server.js
+++ b/http-server.js
@@ -8,7 +8,8 @@ var cors = require('./cors')
 var config = {
   root: path.resolve(process.cwd(), process.env.GIT_HTTP_MOCK_SERVER_ROOT || '.'),
   glob: '*',
-  route: process.env.GIT_HTTP_MOCK_SERVER_ROUTE || '/'
+  route: process.env.GIT_HTTP_MOCK_SERVER_ROUTE || '/',
+  persistChanges: process.env.GIT_HTTP_MOCK_SERVER_PERSIST_CHANGES === 'yes' || false,
 }
 
 var server = http.createServer(cors(factory(config)))

--- a/middleware.js
+++ b/middleware.js
@@ -60,7 +60,7 @@ function factory (config) {
       if (service === 'git-receive-pack') {
         let gitdir = u.pathname.replace(config.route, '').replace(/\/git-receive-pack$/, '').replace(/^\//, '')
         let fixtureName = path.posix.basename(gitdir)
-        return f.copy(fixtureName)
+        return config.persistChanges ? f.find(fixtureName) :f.copy(fixtureName)
       }
     }
     return null


### PR DESCRIPTION
If set to 'yes' copy-on-write will be disabled so that changes will be written to the repository